### PR TITLE
fix: correct user removal to delete only the matching item

### DIFF
--- a/apps/auth/src/users/users.service.ts
+++ b/apps/auth/src/users/users.service.ts
@@ -54,7 +54,7 @@ export class UsersService implements OnModuleInit {
   remove(id: string) {
     const userIndex = this.users.findIndex((user) => user.id === id);
     if (userIndex !== -1) {
-      return this.users.splice(userIndex)[0];
+      return this.users.splice(userIndex, 1)[0];
     }
     throw new NotFoundException(`User not found by id ${id}.`);
   }


### PR DESCRIPTION
Updated the remove method to include the second argument in splice, ensuring that only the user found by ID is removed from the array. Previously, the missing argument caused all users from the found index forward to be removed.